### PR TITLE
chore: add versioning to documentation output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
       outputFrameBufferContextType: 'bitmaprenderer'
     });
     ```
+* Bump minimum Node version to 18.
 
 ### Features
 * Added web worker support

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ The following Video Processors are provided to apply transformations and filters
 ## Prerequisites
 
 * [Twilio Video JavaScript SDK](https://github.com/twilio/twilio-video.js) (v2.29+)
-* [Node.js](https://nodejs.org) (v16+)
-* NPM (v8+, comes installed with newer Node versions)
+* [Node.js](https://nodejs.org) (v18+)
+* NPM (v10+, comes installed with newer Node versions)
 
 ### Note
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/twilio/twilio-video-processors.js.git"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "license": "BSD-3-Clause",
   "main": "./es5/index.js",
@@ -71,8 +71,7 @@
     "ts-node": "^9.1.1",
     "tsify": "^5.0.2",
     "twilio-release-tool": "^1.0.2",
-    "typedoc": "0.25.0",
-    "typedoc-plugin-as-member-of": "^1.0.2",
+    "typedoc": "0.27.6",
     "typescript": "5.2.2",
     "typescript-eslint": "^8.0.1",
     "uglify-js": "^3.17.4",

--- a/typedoc.json
+++ b/typedoc.json
@@ -3,5 +3,6 @@
   "exclude": [
     "tests/**/*"
   ],
-  "out": "dist/docs"
+  "out": "dist/docs",
+  "includeVersion": true
 }


### PR DESCRIPTION
## Pull Request Details

### Description
- now generated docs will include the SDK version
- bump the node.js and npm versions required
- update typedoc
- remove unused typedoc plugin

### Screenshots
<img width="1466" alt="Screenshot 2025-01-14 at 1 13 44 PM" src="https://github.com/user-attachments/assets/b28cd31c-318c-4e49-85f9-ccb544751610" />

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [x] Updated affected documentation
* [ ] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
