### PR TITLE
refactor: implement WebGL2 support detection and fallback to Canvas2D if needed

### DIFF
--- a/karma.conf.ts
+++ b/karma.conf.ts
@@ -20,6 +20,12 @@ export default function(config: any) {
       base: 'Chrome',
       flags: chromeFlags,
     };
+    // Disable GPU to test fallback to Canvas 2D rendering
+    browsers.push('ChromeNoGPU');
+    customLaunchers.ChromeNoGPU = {
+      base: 'Chrome',
+      flags: [...chromeFlags, '--disable-gpu'],
+    };
   } else if (selectedBrowser === 'firefox') {
     browsers.push('FirefoxWebRTC');
     customLaunchers.FirefoxWebRTC = {

--- a/lib/processors/background/BackgroundProcessor.ts
+++ b/lib/processors/background/BackgroundProcessor.ts
@@ -111,7 +111,7 @@ export class BackgroundProcessor<T extends BackgroundProcessorPipeline | Backgro
     // Ensures assetsPath ends with a trailing slash ('/').
     this._assetsPath = assetsPath.replace(/([^/])$/, '$1/');
     this._backgroundProcessorPipeline = backgroundProcessorPipeline;
-    // @ts-ignore
+    // @ts-expect-error - _benchmark is a private property in the pipeline classes definition
     this._benchmark = this._backgroundProcessorPipeline._benchmark;
     this.deferInputFrameDownscale = deferInputFrameDownscale;
     this.maskBlurRadius = maskBlurRadius;

--- a/lib/processors/background/BackgroundProcessor.ts
+++ b/lib/processors/background/BackgroundProcessor.ts
@@ -108,6 +108,7 @@ export class BackgroundProcessor extends Processor {
       throw new Error('assetsPath parameter must be a string');
     }
 
+    // Ensures assetsPath ends with a trailing slash ('/').
     this._assetsPath = assetsPath.replace(/([^/])$/, '$1/');
     this._backgroundProcessorPipeline = backgroundProcessorPipeline;
     // @ts-ignore
@@ -222,14 +223,11 @@ export class BackgroundProcessor extends Processor {
     _benchmark.start('totalProcessingDelay');
     _benchmark.start('processFrameDelay');
 
+    // Extract dimensions based on input frame buffer type
     const {
       width: captureWidth,
       height: captureHeight
-    } = inputFrameBuffer instanceof HTMLVideoElement
-      ? { width: inputFrameBuffer.videoWidth, height: inputFrameBuffer.videoHeight }
-      : typeof VideoFrame === 'function' && inputFrameBuffer instanceof VideoFrame
-        ? { width: inputFrameBuffer.displayWidth, height: inputFrameBuffer.displayHeight }
-        : inputFrameBuffer as (OffscreenCanvas | HTMLCanvasElement);
+    } = this.getFrameDimensions(inputFrameBuffer);
 
     if (this._outputFrameBuffer !== outputFrameBuffer) {
       this._outputFrameBuffer = outputFrameBuffer;
@@ -243,30 +241,26 @@ export class BackgroundProcessor extends Processor {
       this._inputFrameCanvas.height = captureHeight;
     }
 
+    // For HTMLVideoElement, we need to draw it to a canvas first
+    // For other input types (OffscreenCanvas, HTMLCanvasElement, VideoFrame), we can use them directly
     let inputFrame: InputFrame;
     if (inputFrameBuffer instanceof HTMLVideoElement) {
-      this._inputFrameContext.drawImage(
-        inputFrameBuffer,
-        0,
-        0
-      );
+      this._inputFrameContext.drawImage(inputFrameBuffer, 0, 0);
       inputFrame = this._inputFrameCanvas;
     } else {
       inputFrame = inputFrameBuffer;
     }
 
+    // Process the input frame through the appropriate pipeline and return the processed frame
     const outputFrame = _backgroundProcessorPipeline instanceof BackgroundProcessorPipeline
-      ? await (_backgroundProcessorPipeline as BackgroundProcessorPipeline)
-          .render(
-            inputFrame
-          )
-      : await (_backgroundProcessorPipeline as BackgroundProcessorPipelineProxy)
-          .render(
-            inputFrame instanceof OffscreenCanvas
-              ? inputFrame.transferToImageBitmap()
-              : (inputFrame as VideoFrame)
+      ? await _backgroundProcessorPipeline.render(inputFrame)
+      : await _backgroundProcessorPipeline.render(
+          inputFrame instanceof OffscreenCanvas
+            ? inputFrame.transferToImageBitmap()
+            : (inputFrame as VideoFrame) // TODO(lrivas): Review why we need to cast to VideoFrame
           );
 
+    // Render the processed frame to the output buffer
     if (_outputFrameBufferContext instanceof ImageBitmapRenderingContext) {
       const outputBitmap = outputFrame instanceof OffscreenCanvas
         ? outputFrame.transferToImageBitmap()
@@ -282,5 +276,20 @@ export class BackgroundProcessor extends Processor {
 
     _benchmark.end('processFrameDelay');
     _benchmark.start('captureFrameDelay');
+  }
+
+  /**
+   * Gets the dimensions of a frame buffer based on its type
+  */
+  private getFrameDimensions(buffer: OffscreenCanvas | HTMLCanvasElement | HTMLVideoElement | VideoFrame): { width: number, height: number } {
+    if (buffer instanceof HTMLVideoElement) {
+      return { width: buffer.videoWidth, height: buffer.videoHeight };
+    }
+    
+    if (buffer instanceof VideoFrame) {
+      return { width: buffer.displayWidth, height: buffer.displayHeight };
+    }
+    
+    return { width: buffer.width, height: buffer.height };
   }
 }

--- a/lib/processors/background/BackgroundProcessor.ts
+++ b/lib/processors/background/BackgroundProcessor.ts
@@ -257,10 +257,10 @@ export class BackgroundProcessor<T extends BackgroundProcessorPipeline | Backgro
       : await _backgroundProcessorPipeline.render(
           inputFrame instanceof OffscreenCanvas
             ? inputFrame.transferToImageBitmap()
-            : (inputFrame as VideoFrame) // TODO(lrivas): Review why we need to cast to VideoFrame
+            : inputFrame as VideoFrame // TODO(lrivas): Review why we need to cast to VideoFrame, this breaks when using 'canvas' as inputFrameBufferType
           );
 
-    // Render the processed frame to the output buffer
+    // Render the processed frame through the output frame buffer context
     if (_outputFrameBufferContext instanceof ImageBitmapRenderingContext) {
       const outputBitmap = outputFrame instanceof OffscreenCanvas
         ? outputFrame.transferToImageBitmap()

--- a/lib/processors/background/BackgroundProcessor.ts
+++ b/lib/processors/background/BackgroundProcessor.ts
@@ -75,9 +75,9 @@ export interface BackgroundProcessorOptions {
 /**
  * @private
  */
-export class BackgroundProcessor extends Processor {
+export class BackgroundProcessor<T extends BackgroundProcessorPipeline | BackgroundProcessorPipelineProxy = BackgroundProcessorPipeline | BackgroundProcessorPipelineProxy> extends Processor {
   protected readonly _assetsPath: string;
-  protected readonly _backgroundProcessorPipeline: BackgroundProcessorPipeline | BackgroundProcessorPipelineProxy;
+  protected readonly _backgroundProcessorPipeline: T;
 
   private readonly _benchmark: Benchmark;
   private _deferInputFrameDownscale: boolean = false;
@@ -93,7 +93,7 @@ export class BackgroundProcessor extends Processor {
   private readonly _version: string = version;
 
   protected constructor(
-    backgroundProcessorPipeline: BackgroundProcessorPipeline | BackgroundProcessorPipelineProxy,
+    backgroundProcessorPipeline: T,
     options: BackgroundProcessorOptions
   ) {
     super();

--- a/lib/processors/background/BackgroundProcessor.ts
+++ b/lib/processors/background/BackgroundProcessor.ts
@@ -227,7 +227,7 @@ export class BackgroundProcessor<T extends BackgroundProcessorPipeline | Backgro
     const {
       width: captureWidth,
       height: captureHeight
-    } = this.getFrameDimensions(inputFrameBuffer);
+    } = this._getFrameDimensions(inputFrameBuffer);
 
     if (this._outputFrameBuffer !== outputFrameBuffer) {
       this._outputFrameBuffer = outputFrameBuffer;
@@ -281,7 +281,7 @@ export class BackgroundProcessor<T extends BackgroundProcessorPipeline | Backgro
   /**
    * Gets the dimensions of a frame buffer based on its type
   */
-  private getFrameDimensions(buffer: OffscreenCanvas | HTMLCanvasElement | HTMLVideoElement | VideoFrame): { width: number, height: number } {
+  private _getFrameDimensions(buffer: OffscreenCanvas | HTMLCanvasElement | HTMLVideoElement | VideoFrame): { width: number, height: number } {
     if (buffer instanceof HTMLVideoElement) {
       return { width: buffer.videoWidth, height: buffer.videoHeight };
     }

--- a/lib/processors/background/GaussianBlurBackgroundProcessor.ts
+++ b/lib/processors/background/GaussianBlurBackgroundProcessor.ts
@@ -56,7 +56,7 @@ export interface GaussianBlurBackgroundProcessorOptions extends BackgroundProces
  * })();
  * ```
  */
-export class GaussianBlurBackgroundProcessor extends BackgroundProcessor {
+export class GaussianBlurBackgroundProcessor extends BackgroundProcessor<GaussianBlurBackgroundProcessorPipeline | GaussianBlurBackgroundProcessorPipelineProxy> {
   private _blurFilterRadius: number = BLUR_FILTER_RADIUS;
   // tslint:disable-next-line no-unused-variable
   private readonly _name: string = 'GaussianBlurBackgroundProcessor';
@@ -74,6 +74,7 @@ export class GaussianBlurBackgroundProcessor extends BackgroundProcessor {
       useWebWorker = true
     } = options;
 
+    // Ensures assetsPath ends with a trailing slash ('/').
     const assetsPath = options
       .assetsPath
       .replace(/([^/])$/, '$1/');
@@ -113,7 +114,7 @@ export class GaussianBlurBackgroundProcessor extends BackgroundProcessor {
       radius = BLUR_FILTER_RADIUS;
     }
     this._blurFilterRadius = radius;
-    (this._backgroundProcessorPipeline as GaussianBlurBackgroundProcessorPipeline | GaussianBlurBackgroundProcessorPipelineProxy)
+    this._backgroundProcessorPipeline
       .setBlurFilterRadius(this._blurFilterRadius)
       .catch(() => {
         /* noop */

--- a/lib/processors/background/VirtualBackgroundProcessor.ts
+++ b/lib/processors/background/VirtualBackgroundProcessor.ts
@@ -70,7 +70,7 @@ export interface VirtualBackgroundProcessorOptions extends BackgroundProcessorOp
  * img.src = '/background.jpg';
  * ```
  */
-export class VirtualBackgroundProcessor extends BackgroundProcessor {
+export class VirtualBackgroundProcessor extends BackgroundProcessor<VirtualBackgroundProcessorPipeline | VirtualBackgroundProcessorPipelineProxy> {
   private _backgroundImage!: HTMLImageElement;
   private _fitType!: ImageFit;
   // tslint:disable-next-line no-unused-variable
@@ -90,6 +90,7 @@ export class VirtualBackgroundProcessor extends BackgroundProcessor {
       useWebWorker = true
     } = options;
 
+    // Ensures assetsPath ends with a trailing slash ('/').
     const assetsPath = options
       .assetsPath
       .replace(/([^/])$/, '$1/');
@@ -133,7 +134,7 @@ export class VirtualBackgroundProcessor extends BackgroundProcessor {
     }
     this._backgroundImage = image;
     createImageBitmap(this._backgroundImage).then(
-      (imageBitmap) => (this._backgroundProcessorPipeline as VirtualBackgroundProcessorPipeline | VirtualBackgroundProcessorPipelineProxy)
+      (imageBitmap) => this._backgroundProcessorPipeline
         .setBackgroundImage(imageBitmap)
     ).catch(() => {
       /* noop */
@@ -157,7 +158,7 @@ export class VirtualBackgroundProcessor extends BackgroundProcessor {
       fitType = ImageFit.Fill;
     }
     this._fitType = fitType;
-    (this._backgroundProcessorPipeline as VirtualBackgroundProcessorPipeline | VirtualBackgroundProcessorPipelineProxy)
+    this._backgroundProcessorPipeline
       .setFitType(this._fitType)
       .catch(() => {
         /* noop */

--- a/lib/processors/background/pipelines/backgroundprocessorpipeline/BackgroundProcessorPipeline.proxy.ts
+++ b/lib/processors/background/pipelines/backgroundprocessorpipeline/BackgroundProcessorPipeline.proxy.ts
@@ -25,7 +25,7 @@ export class BackgroundProcessorPipelineProxy {
     const outputFrame = await pipelineWorker.render(
       transfer(inputFrame, [inputFrame])
     );
-    // @ts-ignore
+    // @ts-expect-error - _benchmark is a private property in the pipeline classes definition
     this._benchmark.merge(await pipelineWorker._benchmark);
     return outputFrame as ImageBitmap | null;
   }

--- a/lib/processors/background/pipelines/backgroundprocessorpipeline/GaussianBlurBackgroundProcessorPipeline.ts
+++ b/lib/processors/background/pipelines/backgroundprocessorpipeline/GaussianBlurBackgroundProcessorPipeline.ts
@@ -73,7 +73,8 @@ export class GaussianBlurBackgroundProcessorPipeline extends BackgroundProcessor
     } = this;
     this._gaussianBlurFilterPipeline?.cleanUp();
     this._gaussianBlurFilterPipeline = new GaussianBlurFilterPipeline(
-      _webgl2Canvas
+      _webgl2Canvas,
+      _blurFilterRadius
     );
     this._gaussianBlurFilterPipeline!.updateRadius(
       _blurFilterRadius

--- a/lib/processors/background/pipelines/backgroundprocessorpipeline/InputFrameDownscaleStage.ts
+++ b/lib/processors/background/pipelines/backgroundprocessorpipeline/InputFrameDownscaleStage.ts
@@ -2,6 +2,9 @@ import { InputFrame } from '../../../../types';
 import { Pipeline } from '../../../pipelines';
 
 /**
+ * Downscales the input frame to the dimensions of the output canvas using the specified mode and returns the pixel data
+ * @params outputCanvas - The canvas to draw the downscaled image to
+ * @params inputFrameDownscaleMode - The mode to downscale the input frame to
  * @private
  */
 export class InputFrameDowscaleStage implements Pipeline.Stage {

--- a/lib/processors/background/pipelines/backgroundprocessorpipeline/PostProcessingStage.ts
+++ b/lib/processors/background/pipelines/backgroundprocessorpipeline/PostProcessingStage.ts
@@ -64,7 +64,8 @@ export class PostProcessingStage implements Pipeline.Stage {
     this._personMaskUpscalePipeline?.cleanUp();
     this._personMaskUpscalePipeline = new PersonMaskUpscalePipeline(
       _inputDimensions,
-      _webgl2Canvas
+      _webgl2Canvas,
+      _maskBlurRadius
     );
     this._personMaskUpscalePipeline.updateBilateralFilterConfig({
       sigmaSpace: _maskBlurRadius

--- a/lib/processors/background/pipelines/gaussianblurfilterpipeline/index.ts
+++ b/lib/processors/background/pipelines/gaussianblurfilterpipeline/index.ts
@@ -7,11 +7,13 @@ import { SinglePassGaussianBlurFilterStage } from './SinglePassGaussianBlurFilte
 export class GaussianBlurFilterPipeline extends WebGL2Pipeline {
   private _isWebGL2Supported: boolean = true;
   private _outputCanvas: OffscreenCanvas | HTMLCanvasElement;
+  private _blurFilterRadius: number;
 
-  constructor(outputCanvas: OffscreenCanvas | HTMLCanvasElement) {
+  constructor(outputCanvas: OffscreenCanvas | HTMLCanvasElement, blurFilterRadius: number) {
     super();
 
     this._outputCanvas = outputCanvas;
+    this._blurFilterRadius = blurFilterRadius;
     const glOut = outputCanvas.getContext('webgl2');
     if (glOut) {
       this.initializeWebGL2Pipeline(glOut as WebGL2RenderingContext);
@@ -31,7 +33,7 @@ export class GaussianBlurFilterPipeline extends WebGL2Pipeline {
 
   private _renderFallback(): void {
     const ctx = this._outputCanvas.getContext('2d') as CanvasRenderingContext2D;
-    ctx.filter = 'blur(15px)'; // Default blur value from v2.x
+    ctx.filter = `blur(${this._blurFilterRadius}px)`;
   }
 
   private initializeWebGL2Pipeline(glOut: WebGL2RenderingContext): void {
@@ -52,8 +54,9 @@ export class GaussianBlurFilterPipeline extends WebGL2Pipeline {
   }
 
   updateRadius(radius: number): void {
+    this._blurFilterRadius = radius;
     if (!this._isWebGL2Supported) {
-      // Radius is not supported in Canvas2D fallback
+      // SinglePassGaussianBlurFilterStage is not supported in Canvas2D fallback
       return;
     }
     this._stages.forEach(

--- a/lib/processors/background/pipelines/gaussianblurfilterpipeline/index.ts
+++ b/lib/processors/background/pipelines/gaussianblurfilterpipeline/index.ts
@@ -5,11 +5,36 @@ import { SinglePassGaussianBlurFilterStage } from './SinglePassGaussianBlurFilte
  * @private
  */
 export class GaussianBlurFilterPipeline extends WebGL2Pipeline {
+  private _isWebGL2Supported: boolean = true;
+  private _outputCanvas: OffscreenCanvas | HTMLCanvasElement;
+
   constructor(outputCanvas: OffscreenCanvas | HTMLCanvasElement) {
     super();
 
-    const glOut = outputCanvas.getContext('webgl2')! as WebGL2RenderingContext;
+    this._outputCanvas = outputCanvas;
+    const glOut = outputCanvas.getContext('webgl2');
+    if (glOut) {
+      this.initializeWebGL2Pipeline(glOut as WebGL2RenderingContext);
+    } else {
+      this._isWebGL2Supported = false;
+      console.warn('Downgraded to Canvas2D for Gaussian blur due to missing WebGL2 support.');
+    }
+  }
 
+  render(): void {
+    if (!this._isWebGL2Supported) {
+      this._renderFallback();
+    } else {
+      super.render();
+    }
+  }
+
+  private _renderFallback(): void {
+    const ctx = this._outputCanvas.getContext('2d') as CanvasRenderingContext2D;
+    ctx.filter = 'blur(15px)'; // Default blur value from v2.x
+  }
+
+  private initializeWebGL2Pipeline(glOut: WebGL2RenderingContext): void {
     this.addStage(new SinglePassGaussianBlurFilterStage(
       glOut,
       'horizontal',
@@ -27,9 +52,19 @@ export class GaussianBlurFilterPipeline extends WebGL2Pipeline {
   }
 
   updateRadius(radius: number): void {
+    if (!this._isWebGL2Supported) {
+      // Radius is not supported in Canvas2D fallback
+      return;
+    }
     this._stages.forEach(
       (stage) => (stage as SinglePassGaussianBlurFilterStage)
         .updateRadius(radius)
     );
+  }
+
+  cleanUp(): void {
+    if(this._isWebGL2Supported) {
+      super.cleanUp();
+    }
   }
 }

--- a/lib/processors/background/pipelines/personmaskupscalepipeline/index.ts
+++ b/lib/processors/background/pipelines/personmaskupscalepipeline/index.ts
@@ -1,4 +1,4 @@
-import { BilateralFilterConfig, Dimensions } from '../../../../types';
+import { BilateralFilterConfig, Dimensions, InputFrame } from '../../../../types';
 import { WebGL2Pipeline } from '../../../pipelines';
 import { SinglePassBilateralFilterStage } from './SinglePassBilateralFilterStage';
 
@@ -6,16 +6,32 @@ import { SinglePassBilateralFilterStage } from './SinglePassBilateralFilterStage
  * @private
  */
 export class PersonMaskUpscalePipeline extends WebGL2Pipeline {
+  private readonly _outputCanvas: OffscreenCanvas | HTMLCanvasElement;
+  private readonly _inputDimensions: Dimensions;
+  private _isWebGL2Supported: boolean = true;
+  
   constructor(
     inputDimensions: Dimensions,
     outputCanvas: OffscreenCanvas | HTMLCanvasElement
   ) {
     super();
-    const glOut = outputCanvas.getContext('webgl2')! as WebGL2RenderingContext;
+    
+    this._outputCanvas = outputCanvas;
+    this._inputDimensions = inputDimensions;
 
+      const glOut = outputCanvas.getContext('webgl2');
+      if (glOut) {
+        this.initializeWebGL2Pipeline(glOut as WebGL2RenderingContext);
+      } else {
+        this._isWebGL2Supported = false;
+        console.warn('Downgraded to Canvas2D for person mask upscaling due to missing WebGL2 support.');
+      }
+  }
+
+  private initializeWebGL2Pipeline(glOut: WebGL2RenderingContext): void {
     const outputDimensions = {
-      height: outputCanvas.height,
-      width: outputCanvas.width
+      height: this._outputCanvas.height,
+      width: this._outputCanvas.width
     };
 
     this.addStage(new WebGL2Pipeline.InputStage(glOut));
@@ -24,7 +40,7 @@ export class PersonMaskUpscalePipeline extends WebGL2Pipeline {
       glOut,
       'horizontal',
       'texture',
-      inputDimensions,
+      this._inputDimensions,
       outputDimensions,
       1,
       2
@@ -34,13 +50,56 @@ export class PersonMaskUpscalePipeline extends WebGL2Pipeline {
       glOut,
       'vertical',
       'canvas',
-      inputDimensions,
+      this._inputDimensions,
       outputDimensions,
       2
     ));
   }
 
+  render(
+    inputFrame: InputFrame,
+    personMask: ImageData
+  ): void {
+    if (this._isWebGL2Supported) {
+      // Use WebGL2 pipeline when supported
+      super.render(inputFrame, personMask);
+    } else {
+      // Fallback for browsers without WebGL2 support
+      this._renderFallback(inputFrame, personMask);
+    }
+  }
+  
+  /**
+   * Render the person mask using a Canvas 2D context as a fallback for browsers without WebGL2 support
+   * @param inputFrame - The input frame to render
+   * @param personMask - The person mask to render
+   */
+  private _renderFallback(
+    inputFrame: InputFrame,
+    personMask: ImageData
+  ): void {
+    // Create a temporary canvas for the mask
+    const maskCanvas = new OffscreenCanvas(personMask.width, personMask.height);
+    const maskCtx = maskCanvas.getContext('2d')!;
+    maskCtx.putImageData(personMask, 0, 0);
+
+    // Get 2D context for drawing
+    const ctx = this._outputCanvas.getContext('2d') as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+    ctx.save();
+    ctx.filter = 'blur(4px)'; // Default blur value from v2.x
+    ctx.globalCompositeOperation = 'copy';
+    ctx.drawImage(maskCanvas, 0, 0, this._outputCanvas.width, this._outputCanvas.height);
+    ctx.filter = 'none';
+    ctx.globalCompositeOperation = 'source-in';
+    ctx.drawImage(inputFrame, 0, 0, this._outputCanvas.width, this._outputCanvas.height);
+    ctx.restore();
+  }
+
   updateBilateralFilterConfig(config: BilateralFilterConfig) {
+    if (!this._isWebGL2Supported) {
+      // SigmaSpace is not supported in Canvas2D fallback
+      return;
+    }
     const [
       /* inputStage */,
       ...bilateralFilterStages
@@ -54,6 +113,12 @@ export class PersonMaskUpscalePipeline extends WebGL2Pipeline {
           stage.updateSigmaSpace(sigmaSpace);
         }
       );
+    }
+  }
+
+  cleanUp(): void {
+    if(this._isWebGL2Supported) {
+      super.cleanUp();
     }
   }
 }

--- a/lib/utils/TwilioTFLite.ts
+++ b/lib/utils/TwilioTFLite.ts
@@ -77,11 +77,13 @@ export class TwilioTFLite {
 
     tflite._runInference();
 
-    const inputBuffer = this._inputBuffer || new Uint8ClampedArray(pixels * 4);
+    const outputBuffer = this._inputBuffer || new Uint8ClampedArray(pixels * 4);
     for (let i = 0; i < pixels; i++) {
-      inputBuffer![i * 4 + 3] = Math.round(tflite.HEAPF32[tfliteOutputMemoryOffset + i] * 255);
+      // Use the output of the inference to control the alpha channel of the buffer which would result in a person mask
+      // with certains pixels being transparent, semi-transparent or opaque based on the confidence of the model.
+      outputBuffer[i * 4 + 3] = Math.round(tflite.HEAPF32[tfliteOutputMemoryOffset + i] * 255);
     }
-    return inputBuffer!;
+    return outputBuffer;
   }
 
   private async _loadScript(path: string): Promise<void> {

--- a/lib/utils/support.ts
+++ b/lib/utils/support.ts
@@ -8,7 +8,7 @@ function getCanvas() {
 /**
  * Represents the identifier for the rendering context type.
  */
-export type RenderingContextType = '2d' | 'webgl2' | null;
+type RenderingContextType = '2d' | 'webgl2' | null;
 
 
 /**
@@ -17,7 +17,7 @@ export type RenderingContextType = '2d' | 'webgl2' | null;
  * Returns 'webgl2' if available, '2d' if available but webgl2 is not,
  * or null if neither context is available or if running in a non-browser environment.
  */
-export function getRenderingContextType(): RenderingContextType {
+function getRenderingContextType(): RenderingContextType {
   if (typeof window === 'undefined' || typeof document === 'undefined') {
     return null;
   }

--- a/lib/utils/support.ts
+++ b/lib/utils/support.ts
@@ -6,14 +6,37 @@ function getCanvas() {
 }
 
 /**
+ * Represents the identifier for the rendering context type.
+ */
+export type RenderingContextType = '2d' | 'webgl2' | null;
+
+
+/**
+ * @private
+ * @returns {RenderingContextType} Determines the best available rendering context type.
+ * Returns 'webgl2' if available, '2d' if available but webgl2 is not,
+ * or null if neither context is available or if running in a non-browser environment.
+ */
+export function getRenderingContextType(): RenderingContextType {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return null;
+  }
+  const canvas = getCanvas();
+  if (canvas.getContext('webgl2')) {
+    return 'webgl2';
+  }
+  if (canvas.getContext('2d')) {
+    return '2d';
+  }
+  return null;
+}
+
+/**
  * @private
  */
 export function isBrowserSupported() {
-  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-    return !!(getCanvas().getContext('2d') || getCanvas().getContext('webgl2'));
-  } else {
-    return false;
-  }
+  // Check if any supported rendering context is available
+  return getRenderingContextType() !== null;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "author": "Charlie Santos <csantos@twilio.com>",
   "contributors": [
     "Charlie Santos <csantos@twilio.com>",
-    "Manjesh Malavalli <mmalavalli@twilio.com>"
+    "Manjesh Malavalli <mmalavalli@twilio.com>",
+    "Luis Rivas <lrivas@twilio.com>"
   ],
   "keywords": [
     "twilio",


### PR DESCRIPTION
## Pull Request Details

### Description

This update introduces a check for WebGL2 support in the WebGL2 processors, allowing for a fallback to Canvas2D rendering when necessary. Additionally, minor adjustments were made to improve clarity and maintainability in the codebase.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
