### PR TITLE
ci: Pin docker image digest and update dependency caching strategy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ executors:
       - image: twilio/twilio-video-browsers:<<parameters.browser>>-<<parameters.channel>>
   generic-executor:
     docker:
-      - image: alpine:3.7
+      - image: alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 commands:
   get-code:
     steps:
@@ -48,14 +48,14 @@ commands:
     steps:
       - get-code
       - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Installing dependencies
-          command: npm install
+          command: npm ci
       - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:
-            - ./node_modules
+            - ~/.npm
   lint:
     steps:
       - get-code-and-dependencies


### PR DESCRIPTION
## Pull Request Details

### Description

- Pin alpine Docker image to 3.21 with [digest](https://hub.docker.com/layers/library/alpine/3.21/images/sha256-48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d).
- Replace `npm install` with `npm ci` for reproducible builds.
- Cache `~/.npm` instead of `node_modules`, keyed on `package-lock.json`.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review
